### PR TITLE
four scrollbars

### DIFF
--- a/css/theme.css
+++ b/css/theme.css
@@ -4,7 +4,7 @@ body {
   width: 100%;
   background: #232530;
   background-repeat: repeat;
-  overflow: scroll;
+  color-scheme: dark;
 }
 
 body {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/27079662/214487090-1c44e39d-b2a0-499a-b3ec-ed9adb722524.png)

For some reason, the site currently has 2 horizontal and 2 vertical scrollbars. This PR fixes that by removing overflow:scroll from both html and body.

This also adds `color-scheme: dark` which makes it so that on browsers like Chrome, the scrollbars are dark by default. This is what sites like GitHub do to get their dark scrollbar.